### PR TITLE
Switch back to youtube-dl (please work, production server)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -36,7 +36,7 @@ urllib3 = "==1.26.7"
 yarl = "==1.7.2"
 uvloop = "*"
 psutil = "*"
-pytube = "*"
+youtube-dl = "*"
 
 [dev-packages]
 pre-commit = "*"


### PR DESCRIPTION
Now that it's updated, before it raised this:
```
youtube_dl.utils.ExtractorError: Could not find JS function 'na'; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```